### PR TITLE
fix: avoid runtime state overwrite if unchanged

### DIFF
--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -204,7 +204,6 @@ end
 
 # Task to pre-process images before used by other components
 task_context "Preprocess", subclasses: "Base" do
-    reports :PROCESSING_ERROR
     needs_configuration
     input_port('iframe', ro_ptr('base::samples::frame::Frame'))
     output_port 'oframe', ro_ptr('base::samples::frame::Frame')
@@ -234,6 +233,8 @@ task_context "Preprocess", subclasses: "Base" do
 
     property("offset_y",   "int", 0).
        doc "the offset to be used on the left margin in case of scaling"
+    
+    runtime_states :PROCESSING_ERROR
 
     port_driven
 end

--- a/tasks/Preprocess.cpp
+++ b/tasks/Preprocess.cpp
@@ -59,7 +59,9 @@ void Preprocess::updateHook()
     catch(std::runtime_error e)
     {
         RTT::log(RTT::Error) << "processing error: " << e.what() << RTT::endlog();
-        report(PROCESSING_ERROR);
+        if (state() != PROCESSING_ERROR) {
+            state(PROCESSING_ERROR);
+        }
     }
 
     oframe.reset(frame_ptr);


### PR DESCRIPTION
# What is this PR for

Avoid rewriting the runtime state if it is unchanged.
The recurrent state update floods the syskit journalctl
![image](https://github.com/user-attachments/assets/f2dc0b63-94fd-45df-9864-a2b400225bb0)


# Checklist
- [x] Assign yourself  in the PR